### PR TITLE
Increment failed checks at least once

### DIFF
--- a/src/functions/cronTrigger.js
+++ b/src/functions/cronTrigger.js
@@ -141,8 +141,8 @@ export async function processCronTrigger(event) {
       // Save allOperational to false
       monitorsState.lastUpdate.allOperational = false
 
-      // Increment failed checks, only on status change (maybe call it .incidents instead?)
-      if (monitorStatusChanged) {
+      // Increment failed checks on status change or first fail of the day (maybe call it .incidents instead?)
+      if (monitorStatusChanged || monitorsState.monitors[monitor.id].checks[checkDay].fails == 0) {
         monitorsState.monitors[monitor.id].checks[checkDay].fails++
       }
     }


### PR DESCRIPTION
Currently, a failure is only recorded if a monitor transitions from operational
to not in a given day. If the monitor is non-operational at the start of the day,
or remains non-operational for a full day, the failure will not be recorded.